### PR TITLE
Render text right-side-up and translated to the origin

### DIFF
--- a/TextToSvgPath/SpeedyCategories.m
+++ b/TextToSvgPath/SpeedyCategories.m
@@ -67,7 +67,7 @@
 		 and then flip the resulting NSBezierPath right side up again to achieve
 		 our final result with the lines in the right order and the text with
 		 proper orientation.  */
-    [theImage lockFocusFlipped:YES];
+    [theImage lockFocusFlipped:NO];
 
 		/* draw all of the glyphs to collecting them into a bezier path
 		using our custom layout class. */
@@ -95,10 +95,10 @@
     
     transform.m11 =  1.0;
     transform.m12 =  0.0;
-    transform.tX  = -[theFont leading];
+    transform.tX  = -[bezier bounds].origin.x;
     transform.m21 =  0.0;
     transform.m22 =  1.0;
-    transform.tY  = -[bezier bounds].origin.y+[theFont descender];
+    transform.tY  = -[bezier bounds].origin.y;
     //transform.tY  = -[theFont ascender]; // +[theFont descender];
     [affine setTransformStruct:transform];
     [bezier transformUsingAffineTransform:affine];


### PR DESCRIPTION
Thanks for writing this utility, it's super useful! When I used it, I discovered that it was rendering the text vertically flipped, and that the rendered SVG would be clipped by the top and the left sides. These changes seem to alleviate these issues, at least for me.
